### PR TITLE
Add route to get all experiences by chef ID

### DIFF
--- a/core/controllers/chefController.js
+++ b/core/controllers/chefController.js
@@ -1,5 +1,6 @@
 const ChefProfile = require('../models/chefProfileSchema');
 const { validateChefUpdate } = require('../utils/validators');
+const Experience = require('../models/experienceSchema');
 
 exports.createChefProfile = async ({ userId, contactPerson, location, cuisineType, bio, experience, socialLinks }) => {
   const chefProfile = new ChefProfile({
@@ -43,6 +44,16 @@ exports.updateMe = async (req, res) => {
     res.json({ message: 'Perfil de chef actualizado correctamente.', chef: chefProfile });
   } catch (err) {
     res.status(500).json({ message: 'Error al actualizar el perfil de chef.', error: err.message });
+  }
+};
+
+exports.getChefExperiences = async (req, res) => {
+  try {
+    const chefId = req.params.id;
+    const experiences = await Experience.find({ chef: chefId });
+    res.json(experiences);
+  } catch (err) {
+    res.status(500).json({ message: 'Error al obtener las experiencias del chef.', error: err.message });
   }
 };
 

--- a/core/core.md
+++ b/core/core.md
@@ -12,14 +12,14 @@
 
 ### Usuarios
 - [x] `PUT    /api/users/me`              — Actualizar perfil propio
-- [ ] `GET    /api/users/me`              — Obtener perfil propio
-- [ ] `GET    /api/users/:id`             — Obtener perfil público de usuario
+- [X] `GET    /api/users/me`              — Obtener perfil propio
+- [X] `GET    /api/users/:id`             — Obtener perfil público de usuario
 
 ### Chefs/Restaurantes
 - [x] `GET    /api/chefs`                 — Listar chefs/restaurantes
 - [x] `GET    /api/chefs/:id`             — Detalle de chef/restaurante
 - [x] `PUT    /api/chefs/me`              — Actualizar perfil de chef (solo dueño)
-- [ ] `GET    /api/chefs/:id/experiences` — Listar experiencias de un chef
+- [X] `GET    /api/chefs/:id/experiences` — Listar experiencias de un chef
 
 ### Experiencias
 - [X] `GET    /api/experiences`           — Listar experiencias (con filtros)

--- a/core/routes/chefRoutes.js
+++ b/core/routes/chefRoutes.js
@@ -6,4 +6,6 @@ const validateChefUpdate = require('../middlewares/validateChefUpdate');
 
 router.put('/me', auth, validateChefUpdate, chefController.updateMe);
 
+router.get('/:id/experiences', chefController.getChefExperiences);
+
 module.exports = router;


### PR DESCRIPTION
Introduce a new endpoint to retrieve all experiences associated with a specific chef ID. This enhances the API functionality for chefs by allowing access to their experiences.